### PR TITLE
Normalize release version

### DIFF
--- a/dideo.owl
+++ b/dideo.owl
@@ -35,7 +35,7 @@
         <rdfs:comment xml:lang="en">The Drug-drug Interaction and Drug-drug Interaction Evidence Ontology (DIDEO) by the DIDEO development group is licensed under CC BY 4.0. You are free to share (copy and redistribute the material in any medium or format) and adapt (remix, transform, and build upon the material) for any purpose, even commercially. for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow the license terms. You must give appropriate credit (by using the original ontology IRI for the whole ontology and original term IRIs for individual terms), provide a link to the license, and
 indicate if any changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.</rdfs:comment>
         <rdfs:label xml:lang="en">DIDEO</rdfs:label>
-        <owl:versionInfo xml:lang="en">release version 2022-06-14</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">2022-06-14</owl:versionInfo>
     </owl:Ontology>
     
 

--- a/evidence-type-merge/dideo.owl
+++ b/evidence-type-merge/dideo.owl
@@ -25,7 +25,7 @@
         <dc:contributor xml:lang="en">Anuj Shah</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
         <dc:license xml:lang="en">http://creativecommons.org/licenses/by/4.0/</dc:license>
-        <owl:versionInfo xml:lang="en">release version 2017-09-11</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">2017-09-11</owl:versionInfo>
         <dc:contributor xml:lang="en">Jodi Schneider</dc:contributor>
         <dc:contributor xml:lang="en">Richard D. Boyce</dc:contributor>
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>

--- a/evidence-type-merge/gathered.owl
+++ b/evidence-type-merge/gathered.owl
@@ -25,7 +25,7 @@
         <dc:contributor xml:lang="en">Anuj Shah</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
         <dc:license xml:lang="en">http://creativecommons.org/licenses/by/4.0/</dc:license>
-        <owl:versionInfo xml:lang="en">release version 2017-09-11</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">2017-09-11</owl:versionInfo>
         <dc:contributor xml:lang="en">Jodi Schneider</dc:contributor>
         <dc:contributor xml:lang="en">Richard D. Boyce</dc:contributor>
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>

--- a/evidence-type-merge/individuals.owl
+++ b/evidence-type-merge/individuals.owl
@@ -25,7 +25,7 @@
         <dc:contributor xml:lang="en">Anuj Shah</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
         <dc:license xml:lang="en">http://creativecommons.org/licenses/by/4.0/</dc:license>
-        <owl:versionInfo xml:lang="en">release version 2017-09-11</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">2017-09-11</owl:versionInfo>
         <dc:contributor xml:lang="en">Jodi Schneider</dc:contributor>
         <dc:contributor xml:lang="en">Richard D. Boyce</dc:contributor>
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>


### PR DESCRIPTION
I'm not sure how the text `release version` got into the following line

https://github.com/DIDEO/DIDEO/blob/87b68e7408ff4ef6af6ec8fd62e0b5c8dbff7c2e/dideo.owl#L38

but it is irrelevant and means that the version, currently interpreted as `release version 2022-06-14` does not match with the release IRI

https://github.com/DIDEO/DIDEO/blob/87b68e7408ff4ef6af6ec8fd62e0b5c8dbff7c2e/dideo.owl#L18

which would have to read ` <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/dideo/release/release version 2022-06-14/dideo.owl"> ` to be consistent.

This pull request removes the extraneous text `release version` from the text in the `<owl:versionInfo>` of the release file to address the issue..

Further, I wondered how the text within the `<owl:versionInfo>` tag gets there from the development version - is it manually synced, or is there a build scrip that updates the release file from the development file?